### PR TITLE
Loads settings after the plugin is loaded. (Fix for ST 3)

### DIFF
--- a/WordCount.py
+++ b/WordCount.py
@@ -8,6 +8,9 @@ def load_settings():
     global settings
     settings = sublime.load_settings("LaTeXWordCount.sublime-settings")
 
+def plugin_loaded():
+    load_settings()
+
 load_settings()
 settings.add_on_change('reload', lambda:load_settings())
 


### PR DESCRIPTION
In Sublime Text 3, plugins must load their settings after they have been loaded themselves. Therefore, it is necessary to trigger load_settings() in the plugin_loaded() function. This commit fixes the problem and makes SublimeLaTeXWordCount work in ST3 again (it did not work for me before this fix).

See also: http://www.sublimetext.com/forum/viewtopic.php?f=6&t=15160
